### PR TITLE
Allow SQS publisher aws_region attr to be set via alternative env var

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -5,10 +5,10 @@ RET=0
 
 pip uninstall -y $(basename $PWD) || echo "Could not uninstall."
 pip install -U "git+file://$PWD" --no-cache-dir --process-dependency-links
+
 mv powerlibs x
 export $(cat test.env)
 PYTHONPATH=. pytest tests/ || RET=$?
 mv x powerlibs
 
 exit $RET
-

--- a/powerlibs/aws/process_status_notifier/__init__.py
+++ b/powerlibs/aws/process_status_notifier/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from cached_property import cached_property
 
 from powerlibs.aws.sqs.publisher import SQSPublisher
@@ -13,7 +15,8 @@ class ProcessStatusNotifier:
 
     @cached_property
     def notifier(self):
-        return SQSPublisher()
+        aws_region = os.environ.get('AWS_REGION_NAME') or os.environ.get('AWS_REGION')
+        return SQSPublisher(aws_region=aws_region)
 
     def _load_basic_topics(self, topics_format):
         stati = 'started', 'finished', 'failed'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import re
 from setuptools import setup
 
-VERSION = '0.0.3'
+VERSION = '0.0.4'
 
 
 def pip_git_to_setuptools_git(url):

--- a/test.env
+++ b/test.env
@@ -1,3 +1,3 @@
 AWS_ACCESS_KEY_ID=''
 AWS_SECRET_ACCESS_KEY=''
-AWS_REGION=us-east-1
+AWS_REGION_NAME='test-region-name'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+
+BASE_ENVIRON = {
+    'AWS_ACCESS_KEY_ID': 'test-aws-key-id',
+    'AWS_SECRET_ACCESS_KEY': 'shhh...secret',
+}
+
+
+@pytest.fixture
+def aws_region_environ():
+    return {**BASE_ENVIRON, 'AWS_REGION': 'test-region'}
+
+
+@pytest.fixture
+def aws_region_name_environ():
+    return {**BASE_ENVIRON,
+            'AWS_REGION_NAME': 'test-region-name',
+            'AWS_REGION': 'test-region'}
+
+
+@pytest.fixture
+def no_aws_region_environ():
+    return BASE_ENVIRON

--- a/tests/test_aws_region_name_setting.py
+++ b/tests/test_aws_region_name_setting.py
@@ -1,0 +1,24 @@
+from unittest import mock
+
+import pytest
+
+from powerlibs.aws.process_status_notifier import ProcessStatusNotifier
+
+
+def test_with_aws_region(aws_region_environ):
+    with mock.patch.dict('os.environ', aws_region_environ, clear=True):
+        notifier = ProcessStatusNotifier(queue_name='test_queue_name', process_name='test_process_name')
+        assert notifier.notifier.aws_region == 'test-region'
+
+
+def test_with_aws_region_name(aws_region_name_environ):
+    with mock.patch.dict('os.environ', aws_region_name_environ, clear=True):
+        notifier = ProcessStatusNotifier(queue_name='test_queue_name', process_name='test_process_name')
+        assert notifier.notifier.aws_region == 'test-region-name'
+
+
+def test_without_aws_region_at_all(no_aws_region_environ):
+    with mock.patch.dict('os.environ', {}, clear=True):
+        with pytest.raises(KeyError):
+            notifier = ProcessStatusNotifier(queue_name='test_queue_name', process_name='test_process_name')
+            assert notifier.notifier.aws_region == ''


### PR DESCRIPTION
... due to AWS Lambda's restriction over the name AWS_REGION on it's env vars